### PR TITLE
Tempororarily disable LowerAlloca pass

### DIFF
--- a/include/llvm/Analysis/TargetTransformInfo.h
+++ b/include/llvm/Analysis/TargetTransformInfo.h
@@ -244,6 +244,10 @@ public:
   /// optimize away.
   unsigned getFlatAddressSpace() const;
 
+  /// Returns the address space ID for a target's 'private' address space.
+  /// Note this is not necessarily the same as addrspace(0).
+  unsigned getPrivateAddressSpace() const;
+
   /// \brief Test whether calls to a function lower to actual program function
   /// calls.
   ///
@@ -744,6 +748,7 @@ public:
   virtual bool hasBranchDivergence() = 0;
   virtual bool isSourceOfDivergence(const Value *V) = 0;
   virtual unsigned getFlatAddressSpace() = 0;
+  virtual unsigned getPrivateAddressSpace() = 0;
   virtual bool isLoweredToCall(const Function *F) = 0;
   virtual void getUnrollingPreferences(Loop *L, UnrollingPreferences &UP) = 0;
   virtual bool isLegalAddImmediate(int64_t Imm) = 0;
@@ -910,6 +915,9 @@ public:
 
   unsigned getFlatAddressSpace() override {
     return Impl.getFlatAddressSpace();
+  }
+  unsigned getPrivateAddressSpace() override {
+    return Impl.getPrivateAddressSpace();
   }
 
   bool isLoweredToCall(const Function *F) override {

--- a/include/llvm/Analysis/TargetTransformInfoImpl.h
+++ b/include/llvm/Analysis/TargetTransformInfoImpl.h
@@ -175,6 +175,10 @@ public:
     return -1;
   }
 
+  unsigned getPrivateAddressSpace() {
+    return -1;
+  }
+
   bool isLoweredToCall(const Function *F) {
     // FIXME: These should almost certainly not be handled here, and instead
     // handled with the help of TLI or the target itself. This was largely

--- a/include/llvm/CodeGen/BasicTTIImpl.h
+++ b/include/llvm/CodeGen/BasicTTIImpl.h
@@ -98,6 +98,10 @@ public:
     return -1;
   }
 
+  unsigned getPrivateAddressSpace() {
+    return -1;
+  }
+
   bool isLegalAddImmediate(int64_t imm) {
     return getTLI()->isLegalAddImmediate(imm);
   }

--- a/include/llvm/IR/IntrinsicsAMDGPU.td
+++ b/include/llvm/IR/IntrinsicsAMDGPU.td
@@ -82,19 +82,19 @@ defm int_amdgcn_workgroup_id : AMDGPUReadPreloadRegisterIntrinsic_xyz_named
 
 def int_amdgcn_dispatch_ptr :
   GCCBuiltin<"__builtin_amdgcn_dispatch_ptr">,
-  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 2>], [], [IntrNoMem]>;
+  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 4>], [], [IntrNoMem]>;
 
 def int_amdgcn_queue_ptr :
   GCCBuiltin<"__builtin_amdgcn_queue_ptr">,
-  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 2>], [], [IntrNoMem]>;
+  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 4>], [], [IntrNoMem]>;
 
 def int_amdgcn_kernarg_segment_ptr :
   GCCBuiltin<"__builtin_amdgcn_kernarg_segment_ptr">,
-  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 2>], [], [IntrNoMem]>;
+  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 4>], [], [IntrNoMem]>;
 
 def int_amdgcn_implicitarg_ptr :
   GCCBuiltin<"__builtin_amdgcn_implicitarg_ptr">,
-  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 2>], [], [IntrNoMem]>;
+  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 4>], [], [IntrNoMem]>;
 
 def int_amdgcn_groupstaticsize :
   GCCBuiltin<"__builtin_amdgcn_groupstaticsize">,
@@ -106,7 +106,7 @@ def int_amdgcn_dispatch_id :
 
 def int_amdgcn_implicit_buffer_ptr :
   GCCBuiltin<"__builtin_amdgcn_implicit_buffer_ptr">,
-  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 2>], [], [IntrNoMem]>;
+  Intrinsic<[LLVMQualPointerType<llvm_i8_ty, 4>], [], [IntrNoMem]>;
 
 //===----------------------------------------------------------------------===//
 // Instruction Intrinsics

--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -214,6 +214,7 @@ void initializeLoopUnswitchPass(PassRegistry&);
 void initializeLoopVectorizePass(PassRegistry&);
 void initializeLoopVersioningLICMPass(PassRegistry&);
 void initializeLoopVersioningPassPass(PassRegistry &);
+void initializeLowerAllocaPass(PassRegistry &);
 void initializeLowerAtomicLegacyPassPass(PassRegistry &);
 void initializeLowerEmuTLSPass(PassRegistry&);
 void initializeLowerExpectIntrinsicPass(PassRegistry&);

--- a/include/llvm/Transforms/Scalar.h
+++ b/include/llvm/Transforms/Scalar.h
@@ -421,6 +421,15 @@ extern char &InferAddressSpacesID;
 
 //===----------------------------------------------------------------------===//
 //
+// LowerAlloca - Insert address space casts for alloca's returning pointer
+// in the generic address space, which helps subsequent InferAddressSpacePass
+// to replace load/store in generic address space with load/store in private
+// address space.
+//
+BasicBlockPass *createLowerAllocaPass();
+
+//===----------------------------------------------------------------------===//
+//
 // InstructionSimplifier - Remove redundant instructions.
 //
 FunctionPass *createInstructionSimplifierPass();

--- a/lib/Analysis/TargetTransformInfo.cpp
+++ b/lib/Analysis/TargetTransformInfo.cpp
@@ -101,6 +101,10 @@ unsigned TargetTransformInfo::getFlatAddressSpace() const {
   return TTIImpl->getFlatAddressSpace();
 }
 
+unsigned TargetTransformInfo::getPrivateAddressSpace() const {
+  return TTIImpl->getPrivateAddressSpace();
+}
+
 bool TargetTransformInfo::isLoweredToCall(const Function *F) const {
   return TTIImpl->isLoweredToCall(F);
 }

--- a/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
+++ b/lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp
@@ -900,6 +900,7 @@ SDValue SelectionDAGBuilder::getControlRoot() {
 }
 
 void SelectionDAGBuilder::visit(const Instruction &I) {
+  DEBUG(dbgs() << "SelectionDAGBuilder: " << I << '\n');
   // Set up outgoing PHI node register values before emitting the terminator.
   if (isa<TerminatorInst>(&I)) {
     HandlePHINodesInSuccessorBlocks(I.getParent());

--- a/lib/Target/AMDGPU/AMDGPU.h
+++ b/lib/Target/AMDGPU/AMDGPU.h
@@ -166,12 +166,12 @@ enum TargetIndex {
 /// memory locations.
 namespace AMDGPUAS {
 enum AddressSpaces : unsigned {
-  PRIVATE_ADDRESS  = 0, ///< Address space for private memory.
+  FLAT_ADDRESS     = 0, ///< Address space for flat memory.
   GLOBAL_ADDRESS   = 1, ///< Address space for global memory (RAT0, VTX0).
-  CONSTANT_ADDRESS = 2, ///< Address space for constant memory (VTX2)
+  REGION_ADDRESS   = 2, ///< Address space for region memory.
   LOCAL_ADDRESS    = 3, ///< Address space for local memory.
-  FLAT_ADDRESS     = 4, ///< Address space for flat memory.
-  REGION_ADDRESS   = 5, ///< Address space for region memory.
+  CONSTANT_ADDRESS = 4, ///< Address space for constant memory (VTX2)
+  PRIVATE_ADDRESS  = 5, ///< Address space for private memory.
   PARAM_D_ADDRESS  = 6, ///< Address space for direct addressible parameter memory (CONST0)
   PARAM_I_ADDRESS  = 7, ///< Address space for indirect addressible parameter memory (VTX1)
 

--- a/lib/Target/AMDGPU/AMDGPU.td
+++ b/lib/Target/AMDGPU/AMDGPU.td
@@ -397,7 +397,7 @@ def FeatureVolcanicIslands : SubtargetFeatureGeneration<"VOLCANIC_ISLANDS",
    FeatureGCN3Encoding, FeatureCIInsts, Feature16BitInsts,
    FeatureSMemRealTime, FeatureVGPRIndexMode, FeatureMovrel,
    FeatureScalarStores, FeatureInv2PiInlineImm, FeatureSDWA,
-   FeatureApertureRegs, FeatureDPP
+   FeatureDPP
   ]
 >;
 

--- a/lib/Target/AMDGPU/AMDGPU.td
+++ b/lib/Target/AMDGPU/AMDGPU.td
@@ -397,7 +397,7 @@ def FeatureVolcanicIslands : SubtargetFeatureGeneration<"VOLCANIC_ISLANDS",
    FeatureGCN3Encoding, FeatureCIInsts, Feature16BitInsts,
    FeatureSMemRealTime, FeatureVGPRIndexMode, FeatureMovrel,
    FeatureScalarStores, FeatureInv2PiInlineImm, FeatureSDWA,
-   FeatureDPP
+   FeatureApertureRegs, FeatureDPP
   ]
 >;
 

--- a/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -324,6 +324,9 @@ static bool getConstantValue(SDValue N, uint32_t &Out) {
 }
 
 void AMDGPUDAGToDAGISel::Select(SDNode *N) {
+  DEBUG_WITH_TYPE("isel", dbgs() << "[AMDGPUDAGToDAGISel::Select] ";
+    N->dump();
+    dbgs() << '\n');
   unsigned int Opc = N->getOpcode();
   if (N->isMachineOpcode()) {
     N->setNodeId(-1);

--- a/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -1069,7 +1069,7 @@ bool AMDGPUDAGToDAGISel::SelectMUBUFAddr64(SDValue Addr, SDValue &SRsrc,
 
 SDValue AMDGPUDAGToDAGISel::foldFrameIndex(SDValue N) const {
   if (auto FI = dyn_cast<FrameIndexSDNode>(N))
-    return CurDAG->getTargetFrameIndex(FI->getIndex(), FI->getValueType(0));
+    return CurDAG->getTargetFrameIndex(FI->getIndex(), MVT::i32);
   return N;
 }
 
@@ -1100,6 +1100,7 @@ bool AMDGPUDAGToDAGISel::SelectMUBUFScratch(SDValue Addr, SDValue &Rsrc,
 
   // (node)
   VAddr = foldFrameIndex(Addr);
+
   ImmOffset = CurDAG->getTargetConstant(0, DL, MVT::i16);
   return true;
 }

--- a/lib/Target/AMDGPU/AMDGPUOCL12Adapter.cpp
+++ b/lib/Target/AMDGPU/AMDGPUOCL12Adapter.cpp
@@ -68,7 +68,8 @@ static bool isNonDefaultAddrSpacePtr(Type *Ty) {
   StructType* StrType = dyn_cast<StructType>(PtrType->getElementType());
   if(StrType && StrType->isOpaque())
     return false;
-  return (PtrType->getAddressSpace() != 4 && PtrType->getAddressSpace() != 2);
+  return (PtrType->getAddressSpace() != AMDGPUAS::FLAT_ADDRESS &&
+          PtrType->getAddressSpace() != AMDGPUAS::CONSTANT_ADDRESS);
 }
 
 /// \brief Check whether the Function signature has any of the

--- a/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
+++ b/lib/Target/AMDGPU/AMDGPUPrintfRuntimeBinding.cpp
@@ -177,7 +177,7 @@ bool AMDGPUPrintfRuntimeBinding::shouldPrintAsStr(char Specifier,
   if (!PT) {
     return false;
   }
-  if (PT->getAddressSpace() != 2) {
+  if (PT->getAddressSpace() != AMDGPUAS::CONSTANT_ADDRESS) {
     return false;
   }
   Type* ElemType = PT->getContainedType(0);

--- a/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
+++ b/lib/Target/AMDGPU/AMDGPUPromoteAlloca.cpp
@@ -778,12 +778,18 @@ void AMDGPUPromoteAlloca::handleAlloca(AllocaInst &I) {
         continue;
       }
 
+      Type *EltTy = V->getType()->getPointerElementType();
+
       // The operand's value should be corrected on its own and we don't want to
       // touch the users.
-      if (isa<AddrSpaceCastInst>(V))
+      if (auto *ASC = dyn_cast<AddrSpaceCastInst>(V)) {
+        if (ASC->getDestAddressSpace() == AMDGPUAS::PRIVATE_ADDRESS) {
+          PointerType *NewTy = PointerType::get(EltTy, AMDGPUAS::FLAT_ADDRESS);
+          V->mutateType(NewTy);
+        }
         continue;
+      }
 
-      Type *EltTy = V->getType()->getPointerElementType();
       PointerType *NewTy = PointerType::get(EltTy, AMDGPUAS::LOCAL_ADDRESS);
 
       // FIXME: It doesn't really make sense to try to do this for all

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -515,7 +515,9 @@ void AMDGPUPassConfig::addIRPasses() {
   if (TM.getOptLevel() > CodeGenOpt::None) {
     // ToDo: Fix it so that it can handle addrspacecast to private
     //addPass(createAMDGPUPromoteAlloca(&TM));
-    addPass(createLowerAllocaPass());
+    // ToDo: It seems we don't really need LowerAlloca pass here, as we always
+    //       create an addrspacecast right after alloca in the frontend
+    //addPass(createLowerAllocaPass());
     addPass(createInferAddressSpacesPass());
 
     if (EnableSROA)

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -170,7 +170,7 @@ static StringRef computeDataLayout(const Triple &TT) {
 
   // 32-bit private, local, and region pointers. 64-bit global, constant and
   // flat.
-  return "e-p:32:32-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32"
+  return "e-p:64:64-p1:64:64-p3:32:32-p4:64:64-p5:32:32"
          "-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128"
          "-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64";
 }

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -512,9 +512,9 @@ void AMDGPUPassConfig::addIRPasses() {
   addPass(createAMDGPUOpenCLImageTypeLoweringPass());
 
   if (TM.getOptLevel() > CodeGenOpt::None) {
+    addPass(createAMDGPUPromoteAlloca(&TM));
     addPass(createLowerAllocaPass());
     addPass(createInferAddressSpacesPass());
-    addPass(createAMDGPUPromoteAlloca(&TM));
 
     if (EnableSROA)
       addPass(createSROAPass());

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -512,6 +512,7 @@ void AMDGPUPassConfig::addIRPasses() {
   addPass(createAMDGPUOpenCLImageTypeLoweringPass());
 
   if (TM.getOptLevel() > CodeGenOpt::None) {
+    addPass(createLowerAllocaPass());
     addPass(createInferAddressSpacesPass());
     addPass(createAMDGPUPromoteAlloca(&TM));
 

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -170,7 +170,7 @@ static StringRef computeDataLayout(const Triple &TT) {
 
   // 32-bit private, local, and region pointers. 64-bit global, constant and
   // flat.
-  return "e-p:64:64-p1:64:64-p3:32:32-p4:64:64-p5:32:32"
+  return "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32"
          "-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128"
          "-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64";
 }

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -225,7 +225,8 @@ void AMDGPUTargetMachine::addPreLinkPasses(PassManagerBase & PM) {
   PM.add(llvm::createAMDGPUConvertAtomicLibCallsPass());
   PM.add(llvm::createAMDGPUOCL12AdapterPass());
   PM.add(llvm::createAMDGPUPrintfRuntimeBinding());
-  PM.add(llvm::createAMDGPUclpVectorExpansionPass());
+  // ToDo: Do we still need it?
+  //PM.add(llvm::createAMDGPUclpVectorExpansionPass());
 }
 
 void AMDGPUTargetMachine::adjustPassManager(PassManagerBuilder &Builder) {
@@ -512,7 +513,8 @@ void AMDGPUPassConfig::addIRPasses() {
   addPass(createAMDGPUOpenCLImageTypeLoweringPass());
 
   if (TM.getOptLevel() > CodeGenOpt::None) {
-    addPass(createAMDGPUPromoteAlloca(&TM));
+    // ToDo: Fix it so that it can handle addrspacecast to private
+    //addPass(createAMDGPUPromoteAlloca(&TM));
     addPass(createLowerAllocaPass());
     addPass(createInferAddressSpacesPass());
 

--- a/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
+++ b/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
@@ -113,6 +113,10 @@ public:
       AMDGPUAS::FLAT_ADDRESS : AMDGPUAS::UNKNOWN_ADDRESS_SPACE;
   }
 
+  unsigned getPrivateAddressSpace() const {
+    return AMDGPUAS::PRIVATE_ADDRESS;
+  }
+
   unsigned getVectorSplitCost() { return 0; }
 };
 

--- a/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
+++ b/lib/Target/AMDGPU/AMDGPUTargetTransformInfo.h
@@ -105,12 +105,7 @@ public:
   bool isSourceOfDivergence(const Value *V) const;
 
   unsigned getFlatAddressSpace() const {
-    // Don't bother running InferAddressSpaces pass on graphics shaders which
-    // don't use flat addressing.
-    if (IsGraphicsShader)
-      return -1;
-    return ST->hasFlatAddressSpace() ?
-      AMDGPUAS::FLAT_ADDRESS : AMDGPUAS::UNKNOWN_ADDRESS_SPACE;
+    return AMDGPUAS::FLAT_ADDRESS;
   }
 
   unsigned getPrivateAddressSpace() const {

--- a/lib/Target/AMDGPU/AMDGPUclpVectorExpansion.cpp
+++ b/lib/Target/AMDGPU/AMDGPUclpVectorExpansion.cpp
@@ -384,7 +384,7 @@ static Type *getNextType(Type *CurTy, int CurVecSize, int NextVecSize,
   else
     NextTy = VectorType::get(CurEleTy, NextVecSize);
   if (IsPointer) {
-    assert('0' <= NextAddrSpace && NextAddrSpace <= '4' &&
+    assert('0' <= NextAddrSpace && NextAddrSpace <= '5' &&
            "incorrect addrspace");
     NextTy = PointerType::get(
         NextTy, NextAddrSpace == InvalidASChar ? 0 : (NextAddrSpace - '0'));

--- a/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -275,10 +275,8 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS, MVT::i32, Expand);
   setOperationAction(ISD::ATOMIC_CMP_SWAP_WITH_SUCCESS, MVT::i64, Expand);
 
-  if (getSubtarget()->hasFlatAddressSpace()) {
-    setOperationAction(ISD::ADDRSPACECAST, MVT::i32, Custom);
-    setOperationAction(ISD::ADDRSPACECAST, MVT::i64, Custom);
-  }
+  setOperationAction(ISD::ADDRSPACECAST, MVT::i32, Custom);
+  setOperationAction(ISD::ADDRSPACECAST, MVT::i64, Custom);
 
   setOperationAction(ISD::BSWAP, MVT::i32, Legal);
   setOperationAction(ISD::BITREVERSE, MVT::i32, Legal);

--- a/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -278,6 +278,9 @@ SITargetLowering::SITargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::ADDRSPACECAST, MVT::i32, Custom);
   setOperationAction(ISD::ADDRSPACECAST, MVT::i64, Custom);
 
+  // Lower 64 bit frame index to 32 bit target frame index.
+  setOperationAction(ISD::FrameIndex, MVT::i64, Custom);
+
   setOperationAction(ISD::BSWAP, MVT::i32, Legal);
   setOperationAction(ISD::BITREVERSE, MVT::i32, Legal);
 
@@ -2078,6 +2081,7 @@ SDValue SITargetLowering::LowerOperation(SDValue Op, SelectionDAG &DAG) const {
   case ISD::INTRINSIC_W_CHAIN: return LowerINTRINSIC_W_CHAIN(Op, DAG);
   case ISD::INTRINSIC_VOID: return LowerINTRINSIC_VOID(Op, DAG);
   case ISD::ADDRSPACECAST: return lowerADDRSPACECAST(Op, DAG);
+  case ISD::FrameIndex: return lowerFrameIndex(Op, DAG);
   case ISD::INSERT_VECTOR_ELT:
     return lowerINSERT_VECTOR_ELT(Op, DAG);
   case ISD::EXTRACT_VECTOR_ELT:
@@ -2375,6 +2379,33 @@ SDValue SITargetLowering::getSegmentAperture(unsigned AS,
                          MachineMemOperand::MOInvariant);
 }
 
+SDValue SITargetLowering::lowerFrameIndex(SDValue Op,
+                                          SelectionDAG &DAG) const {
+  SDLoc SL(Op);
+  auto *FI = cast<FrameIndexSDNode>(Op);
+
+  // FIXME: Really support non-0 null pointers.
+  SDValue SegmentNullPtr = DAG.getConstant(-1, SL, MVT::i32);
+  SDValue FlatNullPtr = DAG.getConstant(0, SL, MVT::i64);
+
+  MachineFunction &MF = DAG.getMachineFunction();
+  SIMachineFunctionInfo &MFI = *MF.getInfo<SIMachineFunctionInfo>();
+
+  // private -> flat
+  MFI.HasFlatLocalCasts = true;
+  auto Src = DAG.getTargetFrameIndex(FI->getIndex(), MVT::i32);
+  SDValue NonNull
+    = DAG.getSetCC(SL, MVT::i1, Src, SegmentNullPtr, ISD::SETNE);
+
+  SDValue Aperture = getSegmentAperture(AMDGPUAS::PRIVATE_ADDRESS, DAG);
+  SDValue CvtPtr
+    = DAG.getNode(ISD::BUILD_VECTOR, SL, MVT::v2i32, Src, Aperture);
+
+  return DAG.getNode(ISD::SELECT, SL, MVT::i64, NonNull,
+                     DAG.getNode(ISD::BITCAST, SL, MVT::i64, CvtPtr),
+                     FlatNullPtr);
+}
+
 SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
                                              SelectionDAG &DAG) const {
   SDLoc SL(Op);
@@ -2391,6 +2422,11 @@ SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
 
   // flat -> local/private
   if (ASC->getSrcAddressSpace() == AMDGPUAS::FLAT_ADDRESS) {
+    if (ASC->getDestAddressSpace() == AMDGPUAS::PRIVATE_ADDRESS
+        && Src->getOpcode() == ISD::FrameIndex) {
+      return DAG.getTargetFrameIndex(cast<FrameIndexSDNode>(Src.getNode())->
+          getIndex(), MVT::i32);
+    }
     if (ASC->getDestAddressSpace() == AMDGPUAS::LOCAL_ADDRESS)
       MFI.HasFlatLocalCasts = true;
 

--- a/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2426,8 +2426,10 @@ SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
   if (ASC->getSrcAddressSpace() == AMDGPUAS::FLAT_ADDRESS) {
     if (ASC->getDestAddressSpace() == AMDGPUAS::PRIVATE_ADDRESS
         && Src->getOpcode() == ISD::FrameIndex) {
-      return DAG.getTargetFrameIndex(cast<FrameIndexSDNode>(Src.getNode())->
-          getIndex(), MVT::i32);
+      auto TFI = DAG.getTargetFrameIndex(cast<FrameIndexSDNode>(Src.getNode())
+          ->getIndex(), MVT::i32);
+      return SDValue(DAG.getMachineNode(AMDGPU::V_MOV_B32_e32, SL, MVT::i32,
+          TFI), 0);
     }
     if (ASC->getDestAddressSpace() == AMDGPUAS::LOCAL_ADDRESS)
       MFI.HasFlatLocalCasts = true;

--- a/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2354,7 +2354,9 @@ SDValue SITargetLowering::getSegmentAperture(unsigned AS,
   MachineFunction &MF = DAG.getMachineFunction();
   SIMachineFunctionInfo *Info = MF.getInfo<SIMachineFunctionInfo>();
   unsigned UserSGPR = Info->getQueuePtrUserSGPR();
-  assert(UserSGPR != AMDGPU::NoRegister);
+  if (UserSGPR == AMDGPU::NoRegister) {
+    return DAG.getConstant(0, SL, MVT::i32);
+  }
 
   SDValue QueuePtr = CreateLiveInRegister(
     DAG, &AMDGPU::SReg_64RegClass, UserSGPR, MVT::i64);

--- a/lib/Target/AMDGPU/SIISelLowering.h
+++ b/lib/Target/AMDGPU/SIISelLowering.h
@@ -60,6 +60,7 @@ class SITargetLowering final : public AMDGPUTargetLowering {
 
   SDValue getSegmentAperture(unsigned AS, SelectionDAG &DAG) const;
   SDValue lowerADDRSPACECAST(SDValue Op, SelectionDAG &DAG) const;
+  SDValue lowerFrameIndex(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerINSERT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerEXTRACT_VECTOR_ELT(SDValue Op, SelectionDAG &DAG) const;
   SDValue lowerTRAP(SDValue Op, SelectionDAG &DAG) const;

--- a/lib/Target/AMDGPU/SIInstrInfo.td
+++ b/lib/Target/AMDGPU/SIInstrInfo.td
@@ -266,11 +266,6 @@ return CurDAG->getTargetConstant(
   N->getValueAPF().bitcastToAPInt().getZExtValue(), SDLoc(N), MVT::i32);
 }]>;
 
-def frameindex_to_targetframeindex : SDNodeXForm<frameindex, [{
-  auto FI = cast<FrameIndexSDNode>(N);
-  return CurDAG->getTargetFrameIndex(FI->getIndex(), MVT::i32);
-}]>;
-
 // Copied from the AArch64 backend:
 def bitcast_fpimm_to_i64 : SDNodeXForm<fpimm, [{
 return CurDAG->getTargetConstant(

--- a/lib/Target/AMDGPU/SIInstructions.td
+++ b/lib/Target/AMDGPU/SIInstructions.td
@@ -96,9 +96,9 @@ defm V_INTERP_MOV_F32 : VINTRP_m <
 //===----------------------------------------------------------------------===//
 
 def ATOMIC_FENCE : InstSI<
-  (outs), (ins i32imm:$ordering, i32imm:$scope),
+  (outs), (ins i64imm:$ordering, i64imm:$scope),
   "ATOMIC_FENCE $ordering, $scope",
-  [(atomic_fence (i32 imm:$ordering), (i32 imm:$scope))]> {
+  [(atomic_fence (i64 imm:$ordering), (i64 imm:$scope))]> {
   let hasSideEffects = 1;
   let isCodeGenOnly = 1;
   let isPseudo = 1;

--- a/lib/Target/AMDGPU/SIInstructions.td
+++ b/lib/Target/AMDGPU/SIInstructions.td
@@ -846,11 +846,6 @@ def : Pat <
 >;
 
 def : Pat <
- (i32 frameindex:$fi),
- (V_MOV_B32_e32 (i32 (frameindex_to_targetframeindex $fi)))
->;
-
-def : Pat <
   (i64 InlineImm<i64>:$imm),
   (S_MOV_B64 InlineImm<i64>:$imm)
 >;

--- a/lib/Target/NVPTX/CMakeLists.txt
+++ b/lib/Target/NVPTX/CMakeLists.txt
@@ -20,7 +20,6 @@ set(NVPTXCodeGen_sources
   NVPTXInstrInfo.cpp
   NVPTXLowerAggrCopies.cpp
   NVPTXLowerArgs.cpp
-  NVPTXLowerAlloca.cpp
   NVPTXPeephole.cpp
   NVPTXMCExpr.cpp
   NVPTXPrologEpilogPass.cpp

--- a/lib/Target/NVPTX/NVPTX.h
+++ b/lib/Target/NVPTX/NVPTX.h
@@ -51,7 +51,6 @@ MachineFunctionPass *createNVPTXPrologEpilogPass();
 MachineFunctionPass *createNVPTXReplaceImageHandlesPass();
 FunctionPass *createNVPTXImageOptimizerPass();
 FunctionPass *createNVPTXLowerArgsPass(const NVPTXTargetMachine *TM);
-BasicBlockPass *createNVPTXLowerAllocaPass();
 MachineFunctionPass *createNVPTXPeephole();
 
 Target &getTheNVPTXTarget32();

--- a/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -53,7 +53,6 @@ void initializeNVPTXAllocaHoistingPass(PassRegistry &);
 void initializeNVPTXAssignValidGlobalNamesPass(PassRegistry&);
 void initializeNVPTXLowerAggrCopiesPass(PassRegistry &);
 void initializeNVPTXLowerArgsPass(PassRegistry &);
-void initializeNVPTXLowerAllocaPass(PassRegistry &);
 
 } // end namespace llvm
 
@@ -71,7 +70,6 @@ extern "C" void LLVMInitializeNVPTXTarget() {
   initializeNVPTXAllocaHoistingPass(PR);
   initializeNVPTXAssignValidGlobalNamesPass(PR);
   initializeNVPTXLowerArgsPass(PR);
-  initializeNVPTXLowerAllocaPass(PR);
   initializeNVPTXLowerAggrCopiesPass(PR);
 }
 
@@ -192,7 +190,7 @@ void NVPTXPassConfig::addAddressSpaceInferencePasses() {
   // NVPTXLowerArgs emits alloca for byval parameters which can often
   // be eliminated by SROA.
   addPass(createSROAPass());
-  addPass(createNVPTXLowerAllocaPass());
+  addPass(createLowerAllocaPass());
   addPass(createInferAddressSpacesPass());
 }
 

--- a/lib/Target/NVPTX/NVPTXTargetTransformInfo.h
+++ b/lib/Target/NVPTX/NVPTXTargetTransformInfo.h
@@ -49,6 +49,10 @@ public:
     return AddressSpace::ADDRESS_SPACE_GENERIC;
   }
 
+  unsigned getPrivateAddressSpace() const {
+    return AddressSpace::ADDRESS_SPACE_LOCAL;
+  }
+
   // Increase the inlining cost threshold by a factor of 5, reflecting that
   // calls are particularly expensive in NVPTX.
   unsigned getInliningThresholdMultiplier() { return 5; }

--- a/lib/Transforms/Scalar/CMakeLists.txt
+++ b/lib/Transforms/Scalar/CMakeLists.txt
@@ -38,6 +38,7 @@ add_llvm_library(LLVMScalarOpts
   LoopUnrollPass.cpp
   LoopUnswitch.cpp
   LoopVersioningLICM.cpp
+  LowerAlloca.cpp
   LowerAtomic.cpp
   LowerExpectIntrinsic.cpp
   LowerGuardIntrinsic.cpp

--- a/lib/Transforms/Scalar/InferAddressSpaces.cpp
+++ b/lib/Transforms/Scalar/InferAddressSpaces.cpp
@@ -294,6 +294,7 @@ InferAddressSpaces::collectFlatAddressExpressions(Function &F) const {
   // We only explore address expressions that are reachable from loads and
   // stores for now because we aim at generating faster loads and stores.
   for (Instruction &I : instructions(F)) {
+    DEBUG(dbgs() << "check: " << I << '\n');
     if (auto *LI = dyn_cast<LoadInst>(&I))
       PushPtrOperand(LI->getPointerOperand());
     else if (auto *SI = dyn_cast<StoreInst>(&I))
@@ -670,18 +671,17 @@ static bool isSimplePointerUseValidToReplace(Use &U) {
   User *Inst = U.getUser();
   unsigned OpNo = U.getOperandNo();
 
-  if (auto *LI = dyn_cast<LoadInst>(Inst))
-    return OpNo == LoadInst::getPointerOperandIndex() && !LI->isVolatile();
+  if (isa<LoadInst>(Inst))
+    return OpNo == LoadInst::getPointerOperandIndex();
 
-  if (auto *SI = dyn_cast<StoreInst>(Inst))
-    return OpNo == StoreInst::getPointerOperandIndex() && !SI->isVolatile();
+  if (isa<StoreInst>(Inst))
+    return OpNo == StoreInst::getPointerOperandIndex();
 
-  if (auto *RMW = dyn_cast<AtomicRMWInst>(Inst))
-    return OpNo == AtomicRMWInst::getPointerOperandIndex() && !RMW->isVolatile();
+  if (isa<AtomicRMWInst>(Inst))
+    return OpNo == AtomicRMWInst::getPointerOperandIndex();
 
-  if (auto *CmpX = dyn_cast<AtomicCmpXchgInst>(Inst)) {
-    return OpNo == AtomicCmpXchgInst::getPointerOperandIndex() &&
-           !CmpX->isVolatile();
+  if (isa<AtomicCmpXchgInst>(Inst)) {
+    return OpNo == AtomicCmpXchgInst::getPointerOperandIndex();
   }
 
   return false;

--- a/lib/Transforms/Scalar/Scalar.cpp
+++ b/lib/Transforms/Scalar/Scalar.cpp
@@ -67,6 +67,7 @@ void llvm::initializeScalarOpts(PassRegistry &Registry) {
   initializeLoopUnswitchPass(Registry);
   initializeLoopVersioningLICMPass(Registry);
   initializeLoopIdiomRecognizeLegacyPassPass(Registry);
+  initializeLowerAllocaPass(Registry);
   initializeLowerAtomicLegacyPassPass(Registry);
   initializeLowerExpectIntrinsicPass(Registry);
   initializeLowerGuardIntrinsicLegacyPassPass(Registry);

--- a/test/CodeGen/AMDGPU/vgpr-spill-emergency-stack-slot.ll
+++ b/test/CodeGen/AMDGPU/vgpr-spill-emergency-stack-slot.ll
@@ -25,15 +25,15 @@
 ; GCN: NumVgprs: 256
 ; GCN: ScratchSize: 1536
 
-define amdgpu_vs void @main([9 x <16 x i8>] addrspace(2)* byval %arg, [17 x <16 x i8>] addrspace(2)* byval %arg1, [17 x <4 x i32>] addrspace(2)* byval %arg2, [34 x <8 x i32>] addrspace(2)* byval %arg3, [16 x <16 x i8>] addrspace(2)* byval %arg4, i32 inreg %arg5, i32 inreg %arg6, i32 %arg7, i32 %arg8, i32 %arg9, i32 %arg10) #0 {
+define amdgpu_vs void @main([9 x <16 x i8>] addrspace(4)* byval %arg, [17 x <16 x i8>] addrspace(4)* byval %arg1, [17 x <4 x i32>] addrspace(4)* byval %arg2, [34 x <8 x i32>] addrspace(4)* byval %arg3, [16 x <16 x i8>] addrspace(4)* byval %arg4, i32 inreg %arg5, i32 inreg %arg6, i32 %arg7, i32 %arg8, i32 %arg9, i32 %arg10) #0 {
 bb:
-  %tmp = getelementptr [17 x <16 x i8>], [17 x <16 x i8>] addrspace(2)* %arg1, i64 0, i64 0
-  %tmp11 = load <16 x i8>, <16 x i8> addrspace(2)* %tmp, align 16, !tbaa !0
+  %tmp = getelementptr [17 x <16 x i8>], [17 x <16 x i8>] addrspace(4)* %arg1, i64 0, i64 0
+  %tmp11 = load <16 x i8>, <16 x i8> addrspace(4)* %tmp, align 16, !tbaa !0
   %tmp12 = call float @llvm.SI.load.const(<16 x i8> %tmp11, i32 0)
   %tmp13 = call float @llvm.SI.load.const(<16 x i8> %tmp11, i32 16)
   %tmp14 = call float @llvm.SI.load.const(<16 x i8> %tmp11, i32 32)
-  %tmp15 = getelementptr [16 x <16 x i8>], [16 x <16 x i8>] addrspace(2)* %arg4, i64 0, i64 0
-  %tmp16 = load <16 x i8>, <16 x i8> addrspace(2)* %tmp15, align 16, !tbaa !0
+  %tmp15 = getelementptr [16 x <16 x i8>], [16 x <16 x i8>] addrspace(4)* %arg4, i64 0, i64 0
+  %tmp16 = load <16 x i8>, <16 x i8> addrspace(4)* %tmp15, align 16, !tbaa !0
   %tmp17 = add i32 %arg5, %arg7
   %tmp18 = call <4 x float> @llvm.SI.vs.load.input(<16 x i8> %tmp16, i32 0, i32 %tmp17)
   %tmp19 = extractelement <4 x float> %tmp18, i32 0

--- a/test/CodeGen/AMDGPU/wait.ll
+++ b/test/CodeGen/AMDGPU/wait.ll
@@ -11,18 +11,18 @@
 ; DEFAULT: exp
 ; DEFAULT: s_waitcnt lgkmcnt(0)
 ; DEFAULT: s_endpgm
-define amdgpu_vs void @main(<16 x i8> addrspace(2)* inreg %arg, <16 x i8> addrspace(2)* inreg %arg1, <32 x i8> addrspace(2)* inreg %arg2, <16 x i8> addrspace(2)* inreg %arg3, <16 x i8> addrspace(2)* inreg %arg4, i32 inreg %arg5, i32 %arg6, i32 %arg7, i32 %arg8, i32 %arg9, float addrspace(2)* inreg %constptr) #0 {
+define amdgpu_vs void @main(<16 x i8> addrspace(4)* inreg %arg, <16 x i8> addrspace(4)* inreg %arg1, <32 x i8> addrspace(4)* inreg %arg2, <16 x i8> addrspace(4)* inreg %arg3, <16 x i8> addrspace(4)* inreg %arg4, i32 inreg %arg5, i32 %arg6, i32 %arg7, i32 %arg8, i32 %arg9, float addrspace(4)* inreg %constptr) #0 {
 main_body:
-  %tmp = getelementptr <16 x i8>, <16 x i8> addrspace(2)* %arg3, i32 0
-  %tmp10 = load <16 x i8>, <16 x i8> addrspace(2)* %tmp, !tbaa !0
+  %tmp = getelementptr <16 x i8>, <16 x i8> addrspace(4)* %arg3, i32 0
+  %tmp10 = load <16 x i8>, <16 x i8> addrspace(4)* %tmp, !tbaa !0
   %tmp11 = call <4 x float> @llvm.SI.vs.load.input(<16 x i8> %tmp10, i32 0, i32 %arg6)
   %tmp12 = extractelement <4 x float> %tmp11, i32 0
   %tmp13 = extractelement <4 x float> %tmp11, i32 1
   call void @llvm.amdgcn.s.barrier() #1
   %tmp14 = extractelement <4 x float> %tmp11, i32 2
-  %tmp15 = load float, float addrspace(2)* %constptr, align 4
-  %tmp16 = getelementptr <16 x i8>, <16 x i8> addrspace(2)* %arg3, i32 1
-  %tmp17 = load <16 x i8>, <16 x i8> addrspace(2)* %tmp16, !tbaa !0
+  %tmp15 = load float, float addrspace(4)* %constptr, align 4
+  %tmp16 = getelementptr <16 x i8>, <16 x i8> addrspace(4)* %arg3, i32 1
+  %tmp17 = load <16 x i8>, <16 x i8> addrspace(4)* %tmp16, !tbaa !0
   %tmp18 = call <4 x float> @llvm.SI.vs.load.input(<16 x i8> %tmp17, i32 0, i32 %arg6)
   %tmp19 = extractelement <4 x float> %tmp18, i32 0
   %tmp20 = extractelement <4 x float> %tmp18, i32 1
@@ -43,18 +43,18 @@ main_body:
 ; ILPMAX: s_waitcnt vmcnt(1)
 ; ILPMAX: s_waitcnt vmcnt(0)
 ; ILPMAX: s_endpgm
-define amdgpu_vs void @main2([6 x <16 x i8>] addrspace(2)* byval %arg, [17 x <16 x i8>] addrspace(2)* byval %arg1, [17 x <4 x i32>] addrspace(2)* byval %arg2, [34 x <8 x i32>] addrspace(2)* byval %arg3, [16 x <16 x i8>] addrspace(2)* byval %arg4, i32 inreg %arg5, i32 inreg %arg6, i32 %arg7, i32 %arg8, i32 %arg9, i32 %arg10) #0 {
+define amdgpu_vs void @main2([6 x <16 x i8>] addrspace(4)* byval %arg, [17 x <16 x i8>] addrspace(4)* byval %arg1, [17 x <4 x i32>] addrspace(4)* byval %arg2, [34 x <8 x i32>] addrspace(4)* byval %arg3, [16 x <16 x i8>] addrspace(4)* byval %arg4, i32 inreg %arg5, i32 inreg %arg6, i32 %arg7, i32 %arg8, i32 %arg9, i32 %arg10) #0 {
 main_body:
-  %tmp = getelementptr [16 x <16 x i8>], [16 x <16 x i8>] addrspace(2)* %arg4, i64 0, i64 0
-  %tmp11 = load <16 x i8>, <16 x i8> addrspace(2)* %tmp, align 16, !tbaa !0
+  %tmp = getelementptr [16 x <16 x i8>], [16 x <16 x i8>] addrspace(4)* %arg4, i64 0, i64 0
+  %tmp11 = load <16 x i8>, <16 x i8> addrspace(4)* %tmp, align 16, !tbaa !0
   %tmp12 = add i32 %arg5, %arg7
   %tmp13 = call <4 x float> @llvm.SI.vs.load.input(<16 x i8> %tmp11, i32 0, i32 %tmp12)
   %tmp14 = extractelement <4 x float> %tmp13, i32 0
   %tmp15 = extractelement <4 x float> %tmp13, i32 1
   %tmp16 = extractelement <4 x float> %tmp13, i32 2
   %tmp17 = extractelement <4 x float> %tmp13, i32 3
-  %tmp18 = getelementptr [16 x <16 x i8>], [16 x <16 x i8>] addrspace(2)* %arg4, i64 0, i64 1
-  %tmp19 = load <16 x i8>, <16 x i8> addrspace(2)* %tmp18, align 16, !tbaa !0
+  %tmp18 = getelementptr [16 x <16 x i8>], [16 x <16 x i8>] addrspace(4)* %arg4, i64 0, i64 1
+  %tmp19 = load <16 x i8>, <16 x i8> addrspace(4)* %tmp18, align 16, !tbaa !0
   %tmp20 = add i32 %arg5, %arg7
   %tmp21 = call <4 x float> @llvm.SI.vs.load.input(<16 x i8> %tmp19, i32 0, i32 %tmp20)
   %tmp22 = extractelement <4 x float> %tmp21, i32 0

--- a/test/CodeGen/AMDGPU/waitcnt.mir
+++ b/test/CodeGen/AMDGPU/waitcnt.mir
@@ -3,8 +3,8 @@
 --- |
   define void @flat_zero_waitcnt(i32 addrspace(1)* %global4,
                                  <4 x i32> addrspace(1)* %global16,
-                                 i32 addrspace(4)* %flat4,
-                                 <4 x i32> addrspace(4)* %flat16) {
+                                 i32* %flat4,
+                                 <4 x i32>* %flat16) {
     ret void
   }
 

--- a/test/Transforms/LoopStrengthReduce/AMDGPU/different-addrspace-crash.ll
+++ b/test/Transforms/LoopStrengthReduce/AMDGPU/different-addrspace-crash.ll
@@ -1,6 +1,7 @@
 ; RUN: llc < %s | FileCheck %s
 
-target datalayout = "e-p:32:32-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
+target datalayout = "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64"
+
 target triple = "amdgcn--"
 
 ; We need to compile this for a target where we have different address spaces,
@@ -21,9 +22,9 @@ entry:
 
 loop:
   %idx0 = phi i32 [ %next_idx0, %loop ], [ 0, %entry ]
-  %0 = getelementptr inbounds i32, i32* null, i32 %idx0
+  %0 = getelementptr inbounds i32, i32 addrspace(5)* null, i32 %idx0
   %1 = getelementptr inbounds i32, i32 addrspace(1)* null, i32 %idx0
-  store i32 1, i32* %0
+  store i32 1, i32 addrspace(5)* %0
   store i32 7, i32 addrspace(1)* %1
   %next_idx0 = add nuw nsw i32 %idx0, 1
   br label %loop

--- a/test/Transforms/LowerAlloca/AMDGPU/lower-alloca.ll
+++ b/test/Transforms/LowerAlloca/AMDGPU/lower-alloca.ll
@@ -1,0 +1,14 @@
+; RUN: opt < %s -S -lower-alloca -infer-address-spaces | FileCheck %s
+
+target triple = "amdgcn-amd-amdhsa"
+
+define  void @kernel() {
+; LABEL: @lower_alloca
+  %A = alloca i32
+; CHECK: addrspacecast i32* %A to i32 addrspace(5)*
+; CHECK: store i32 0, i32 addrspace(5)* {{%.+}}
+  store i32 0, i32* %A
+  call void @callee(i32* %A)
+  ret void
+}
+declare void @callee(i32*)

--- a/test/Transforms/LowerAlloca/NVPTX/lower-alloca.ll
+++ b/test/Transforms/LowerAlloca/NVPTX/lower-alloca.ll
@@ -1,4 +1,4 @@
-; RUN: opt < %s -S -nvptx-lower-alloca -infer-address-spaces | FileCheck %s
+; RUN: opt < %s -S -lower-alloca -infer-address-spaces | FileCheck %s
 ; RUN: llc < %s -march=nvptx64 -mcpu=sm_35 | FileCheck %s --check-prefix PTX
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v32:32:32-v64:64:64-v128:128:128-n16:32:64"


### PR DESCRIPTION
In the frontend an addrspacecast is already produced for alloca. Empirical
testing shows adding LowerAlloca would produce additional addrspacecast and
confuses other opt passes, and eventually lead the backend to crash for
ROCm-Device-Libs tests.

This commit disables LowerAlloca pass in AMDGPUTargetMachine, and it allows
ROCm-Device-Libs be built and tested end-to-end.